### PR TITLE
refactor: Update CORS configuration to allow specific origins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,50 @@
 const express = require('express');
 const { router } = require('./app/routes/index');
 const path = require('path');
+const cors = require('cors');
 
 // Server
 const app = express();
-app.set('port', 4000);
-app.listen(app.get('port'));
-console.log(`Servidor corriendo en http://localhost:${app.get('port')}/`);
+const port = process.env.PORT || 4000;
+app.listen(port);
+console.log(`Servidor corriendo en http://localhost:${port}/`);
 
 // Configuracion
-app.use(express.static(path.join(__dirname, 'public'))); // Rutas de prueba
+app.use(express.static(path.join(__dirname, '/app/public'))); // Rutas de prueba
 app.use(express.json()); // Para que express pueda entender los datos que vienen del cliente
+
+// Cors
+const corsOptions = {
+  origin: function (origin, callback) {
+    const allowedOrigins = [
+      'http://localhost:4000',
+      'http://localhost:5173',
+      'https://rippio.netlify.app',
+    ];
+
+    if (!origin || allowedOrigins.indexOf(origin) !== -1) {
+      callback(null, true);
+    } else {
+      callback(new Error('Origin not allowed'), false);
+    }
+  },
+};
+
+app.use(cors(corsOptions));
 
 // Rutas API
 app.use('/api', router);
 
 // Rutas de pruebas para el login
 app.get('/', (req, res) =>
-  res.sendFile(path.join(__dirname, '/pages/login.html'))
+  res.sendFile(path.join(__dirname, '/app/pages/login.html'))
 );
 app.get('/forgot-password', (req, res) =>
-  res.sendFile(path.join(__dirname, '/pages/forgot-password.html'))
+  res.sendFile(path.join(__dirname, '/app/pages/forgot-password.html'))
 );
 app.get('/reset-password', (req, res) =>
-  res.sendFile(path.join(__dirname, '/pages/reset-password.html'))
+  res.sendFile(path.join(__dirname, '/app/pages/reset-password.html'))
 );
 app.get('/login', (req, res) =>
-  res.sendFile(path.join(__dirname, '/pages/login.html'))
+  res.sendFile(path.join(__dirname, '/app/pages/login.html'))
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "nodemailer": "^6.9.13",
@@ -338,6 +339,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^6.9.13",


### PR DESCRIPTION
The code changes in this commit update the CORS configuration in the `index.js` file to allow specific origins for cross-origin resource sharing. The allowed origins include `http://localhost:4000`, `http://localhost:5173`, and `https://rippio.netlify.app`. This ensures that requests from these origins are allowed by the server, while requests from other origins are rejected. This improves security and restricts access to the server resources.